### PR TITLE
Isolate Docker-absent updater test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+This repository treats ordinary PRs and releases differently.
+
+Ordinary PRs change code, tests, or internal docs and do not create tags, GitHub Releases, or installer history entries. Releases are only for changes that are meant to be published to users, including public runtime scripts and any material change to install, update, recovery, or safety commands.
+
+## What counts as a release
+
+Use `scripts/release.sh` as the tag and GitHub Release gate. It will only create a release when all of these are true:
+
+- the working tree is clean
+- the branch is `public-clean`
+- local `HEAD` matches `origin/main`
+- the latest GitHub Actions `Verify scripts` run for that `HEAD` succeeded
+- `CHANGELOG.md` has a section for the release version
+- public metadata has no private device identifiers
+- the tag and GitHub Release do not already exist
+
+`scripts/verify-scripts.sh` is the release verification contract. It checks bash syntax, ShellCheck when installed, `--version` support on the installer and updater family, version consistency across `VERSION` and every public `SCRIPT_VERSION`, unsafe heredoc wrappers, and installer safety invariants.
+
+Publishing commits and creating a release are separate steps. `scripts/publish-public.sh` pushes local `public-clean` to `origin/main`; after the resulting `Verify scripts` run succeeds, `scripts/release.sh` creates the version tag and GitHub Release.
+
+If a change would make users fetch or reset `main` to get it, it is effectively publication. That includes merging public runtime scripts and materially changing published install, update, recovery, or shutdown commands. Prepare the release metadata before publishing those changes to `main`.
+
+## What does not count as a release
+
+These are ordinary PRs, not releases:
+
+- tests only, including `tests/test-system-package-updater.sh`
+- CI-only changes
+- internal developer docs, including this file
+- non-user-facing maintenance code that does not change published commands or shipped behavior
+
+Issue #14 is the test-only example here. Its fix touches only `tests/test-system-package-updater.sh`, so it needs no version bump.
+
+## Release decision table
+
+| Change type | Release? | Bump | Notes |
+| --- | --- | --- | --- |
+| Test-only fix | No | None | Example: issue #14, tests only, no shipped behavior changes |
+| CI-only change | No | None | Workflow, lint, or verification plumbing only |
+| Internal docs, including CONTRIBUTING | No | None | Developer-facing only |
+| Public README safety or command guidance | Usually yes | PATCH or MINOR | If it changes what users are told to run, treat it like published guidance |
+| Public runtime script behavior | Yes | PATCH or MINOR while pre-1.0 | Comments and internal refactors alone do not trigger a release |
+| Installer, updater, recovery, or shutdown command behavior | Yes | PATCH or MINOR while pre-1.0 | If users fetch `main` to get the fix, it is publication |
+| Migration or installed-state change | Yes | PATCH or MINOR while pre-1.0 | Include linear updater history and any state recording needed on installed hosts |
+| Release tooling changes, including `scripts/release.sh` or `scripts/verify-scripts.sh` | No | None | Usually ordinary PR work unless the tooling change itself alters published behavior |
+
+## Version policy for this 0.x project
+
+This repository is pre-1.0, so compatibility is narrower than a stable `1.x` line.
+
+- `PATCH`, such as `0.5.26` to `0.5.27`, means a backward-compatible bug fix, hardening change, or published documentation correction.
+- `MINOR`, such as `0.5.x` to `0.6.0`, means a new user-facing capability or a deliberate contract change during the pre-1.0 period. Breaking command, migration, or installed-state changes require explicit release notes and an upgrade path.
+- `MAJOR`, meaning `1.0.0`, is reserved for declaring a stable public contract. Do not use it merely because a pre-1.0 change is incompatible.
+
+For 0.x, be strict about what counts as compatible. Prefer `PATCH` when existing commands and installed hosts continue to work unchanged. Use `MINOR` when users or installed hosts must follow a new contract, and document the transition before merge.
+
+## Release obligations
+
+Before a release, update and verify all of these together:
+
+1. `VERSION`
+2. every public `SCRIPT_VERSION` value that `scripts/verify-scripts.sh` expects to match that version
+3. the matching `## <version>` section in `CHANGELOG.md`
+4. any linear updater history or installed-state migration needed for hosts already on disk
+5. tests and the `Verify scripts` CI run for the release commit
+6. the public metadata scrub and all gates enforced by `scripts/release.sh`
+
+The release commit should make `scripts/verify-scripts.sh` pass. Then publish `public-clean` to `origin/main` with `scripts/publish-public.sh`, wait for the `Verify scripts` workflow to pass on that commit, and run `scripts/release.sh` to create the tag and GitHub Release.
+
+## Practical rule of thumb
+
+If the change affects what users run, what users see in the public README, or what an installed ODROID M1S stores and replays later, assume it needs a release. If it only helps contributors develop, test, or review the project, keep it as an ordinary PR.

--- a/tests/test-sync-dev-tracker.sh
+++ b/tests/test-sync-dev-tracker.sh
@@ -38,6 +38,7 @@ print(Path(sys.argv[1]).read_text(encoding='utf-8'))
 PY
 )"
 current_branch="$(git branch --show-current)"
+current_branch="${current_branch:-DETACHED_HEAD}"
 current_version="$(<VERSION)"
 expected_branch_line="Branch: \`${current_branch}\`"
 expected_version_line="Working version: \`${current_version}\`"

--- a/tests/test-system-package-updater.sh
+++ b/tests/test-system-package-updater.sh
@@ -282,12 +282,17 @@ cat > "$TEST_TMPDIR/bin/systemctl" <<'EOF'
 printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
 EOF
 chmod +x "$TEST_TMPDIR/bin/"*
+ln -s "$BASH" "$TEST_TMPDIR/bin/bash"
 APT_LOG="$TEST_TMPDIR/apt.log"
 DPKG_LOG="$TEST_TMPDIR/dpkg.log"
 SYSTEMCTL_LOG="$TEST_TMPDIR/systemctl.log"
 export APT_LOG DPKG_LOG SYSTEMCTL_LOG
-PATH="$TEST_TMPDIR/bin:/bin"
 (
+  PATH="$TEST_TMPDIR/bin"
+  export PATH
+  if command -v docker >/dev/null 2>&1; then
+    fail 'Docker absent path should not resolve docker before main'
+  fi
   require_root() { return 0; }
   reboot_required() { return 1; }
   DRY_RUN=0
@@ -295,7 +300,8 @@ PATH="$TEST_TMPDIR/bin:/bin"
   CONTAINERS_STOPPED=0
   REBOOTING=0
   STOPPED_CONTAINERS=()
-  main
+  main_output="$(main 2>&1)"
+  assert_contains "$main_output" 'Docker is not installed or not in PATH; continuing with package update only.' 'Docker absent path should print the exact no-Docker warning'
 )
 [[ ! -e "$TEST_TMPDIR/docker.log" ]] || fail 'Docker absent path should not call docker'
 apt_log="$(cat "$APT_LOG")"


### PR DESCRIPTION
## Summary

- isolate the system package updater's Docker-absent test from host `/bin` and `/usr/bin`
- assert that Docker is unresolvable and that the exact no-Docker warning branch runs
- document when ordinary PRs require version bumps, release metadata, migrations, tags, and GitHub Releases
- make the tracker test use the same `DETACHED_HEAD` fallback as the implementation so PR CI can validate the change
- keep `VERSION` and `CHANGELOG.md` unchanged because this is a test-only fix plus internal contributor documentation

## Verification

- `bash -n tests/test-system-package-updater.sh`
- `shellcheck -x tests/test-system-package-updater.sh`
- `bash tests/test-system-package-updater.sh`
- `bash tests/test-sync-dev-tracker.sh` in attached and detached HEAD worktrees
- `bash scripts/verify-scripts.sh` in a detached HEAD worktree
- Docker guard confirmed zero calls from `tests/test-system-package-updater.sh`
- five-lane goal, QA, code quality, security, and repository-context review passed
- GitHub Actions `verify-scripts` passed on the PR head

Closes #14